### PR TITLE
Fixed image loading error and Grammatical Issues

### DIFF
--- a/docs/check/overview.md
+++ b/docs/check/overview.md
@@ -7,16 +7,16 @@ sidebar_label: Run Benchmarks
 
 Steampipe **controls** and **benchmarks** provide a generic mechanism for defining and running control frameworks such as CIS, NIST, HIPAA, etc, as well as your own customized groups of controls.
 
-There are many control frameworks in existence today, and though they are all implemented with their own specific syntax and structure, they are generally organized in a defined, hierarchical structure, with a pass/fail type of [status](/docs/reference/mod-resources/control#control-statuses) for each item.  The control and benchmark resources allow Steampipe to provide simplified, consistent mechanisms for defining, running, and returning output from these disparate frameworks.
+There are many control frameworks in existence today, and though they are all implemented with their own specific syntax and structure, they are generally organized in a defined, hierarchical structure, with a pass/fail type of [status](/docs/reference/mod-resources/control#control-statuses) for each item. The control and benchmark resources allow Steampipe to provide simplified, consistent mechanisms for defining, running, and returning output from these disparate frameworks.
 
 
-Steampipe benchmarks automatically appear as [dashboards](/docs/dashboard/overview) when you run `steampipe dashboard` in the mod.  From the dashboard home, you can select any benchmark to run it and view it in an interactive HTML format.  You can even export the benchmark results as a CSV from the [panel view](/docs/dashboard/panel).
+Steampipe benchmarks automatically appear as [dashboards](/docs/dashboard/overview) when you run `steampipe dashboard` in the mod. From the dashboard home, you can select any benchmark to run and view it in an interactive HTML format. You can even export the benchmark results as a CSV from the [panel view](/docs/dashboard/panel).
 
 <img src="/images/reference_examples/benchmark_dashboard_view.png" />
 
 <br />
 
-You can also run controls and benchmarks in batch mode with the [steampipe check](/docs/reference/cli/check) command.  The `steampipe check` command provides options for selecting which controls to run, supports many output formats, and provides capabilities often required when using `steampipe` in your scripts, pipelines, and other automation scenarios.  
+You can also run controls and benchmarks in batch mode with the [steampipe check](/docs/reference/cli/check) command. The `steampipe check` command provides options for selecting which controls to run, supports many output formats, and provides capabilities often required when using `steampipe` in your scripts, pipelines, and other automation scenarios.  
 
 To run every benchmark in the mod:
 
@@ -24,21 +24,17 @@ To run every benchmark in the mod:
 steampipe check all
 ```
 
-The console will show progress as its runs, and will print the results to the screen when it is complete:
+The console will show progress as it runs, and will print the results to the screen when it completes.
 
-<img src="/images/steampipe-check-output-sample-1.png" width="100%" />
-
-
+<!-- <img src="/images/steampipe-check-output-sample-1.png" width="100%" /> -->
 
 You can find controls and benchmarks in the [Steampipe Mods](https://hub.steampipe.io/mods) section of the [Steampipe Hub](https://hub.steampipe.io), or by searching [Github](https://github.com/topics/steampipe-mod) directly.  
 
 You can also [create your own controls and benchmarks](/docs/mods/writing-controls), and package them into a [mod](/docs/reference/mod-resources/overview).  
 
-
-
 ## More Examples
 
-The [steampipe check](reference/cli/check) command executes one or more Steampipe benchmarks and controls.  You may specify one or more benchmarks or controls to run, or run steampipe check all to run all 
+The [steampipe check](reference/cli/check) command executes one or more Steampipe benchmarks and controls. You may specify one or more benchmarks or controls to run, or run steampipe check all to run all 
 
 You can run all controls in the workspace:
 ```bash
@@ -66,19 +62,12 @@ Usually, steampipe mods use unqualified queries to "target" whichever connection
 steampipe check all --search-path-prefix aws_connection_2
 ```
 
-
 You can filter the controls to run using a where clause on the steampipe_control reflection table.  
 ```bash
 steampipe check all --where "severity in ('critical', 'high')"
 ```
 
-
-
 You can preview which controls with the `--dry-run` flag:
 ```bash
 steampipe check all --where "severity in ('critical', 'high')" --dry-run
 ```
-
-
-
-


### PR DESCRIPTION
The image which is mentioned in this isn't there in the whole repo, so for now I have commented the image attribute because it was generating a loading error, you can use it again in the future by uncommenting the image attribute.

Along with this, there were some grammatical mistakes which are fixed now.

Already starred the repo :)