### PR TITLE
add version for plugin library import

### DIFF
--- a/docs/develop/writing-plugins.md
+++ b/docs/develop/writing-plugins.md
@@ -31,7 +31,7 @@ The `main` function in then `main.go` is the entry point for your plugin.  This 
 package main
 
 import (
-	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-zendesk/zendesk"
 )
 


### PR DESCRIPTION
Major semver revisions are treated as different import paths in go. Go get fetches old version without v5 in the package import name. 

Without defining 'v5' this error is produced on `go build`: 

```
# github.com/turbot/steampipe-plugin-sdk/plugin
../../go/pkg/mod/github.com/turbot/steampipe-plugin-sdk@v1.8.3/plugin/hydrate.go:17:18: assignment mismatch: 2 variables but retry.NewFibonacci returns 1 value
```

With 'v5' the correct package version is used and the build proceeds. 
