### PR TITLE
Update introspection example in key-columns.md

### DIFF
--- a/docs/guides/key-columns.md
+++ b/docs/guides/key-columns.md
@@ -139,7 +139,7 @@ select
   name,
   type,
   (get_config || list_config) -> 'operators' as operators,
-  coalesce((get_config || list_config) ->> 'required', 'optional') as required
+  coalesce((get_config || list_config) ->> 'require', 'optional') as required
 from 
   steampipe_plugin_column
 where


### PR DESCRIPTION
probably a typo, causing all values in the `required` column to be `optional`

after the change:
![image](https://github.com/turbot/steampipe-docs/assets/37073878/019ee9cf-14c3-4baf-89d0-4989c58e610c)
