### PR TITLE
docs: add doc for STEAMPIPE_DATABASE_SSL_PASSWORD env var

### DIFF
--- a/docs/managing/service.md
+++ b/docs/managing/service.md
@@ -78,10 +78,10 @@ Managing the Steampipe service:
 
 ## Starting database with a private key protected with a passphrase
 
-You can run `steampipe service start` with a private key protected with a passphrase, use the `--database-ssl-password` flag
+You can run `steampipe service start` with a private key protected with a passphrase, use the `STEAMPIPE_DATABASE_SSL_PASSWORD` environement variable
 
 ```bash
-$ steampipe service start --database-ssl-password my-passphrase
+$ STEAMPIPE_DATABASE_SSL_PASSWORD=my-passphrase steampipe service start
 
 Steampipe service is running:
 

--- a/docs/managing/service.md
+++ b/docs/managing/service.md
@@ -12,7 +12,8 @@ Alternatively, you can run Steampipe in service mode.  Running `steampipe servic
 ## Starting the database in service mode
 
 When you run `steampipe service start`, Steampipe will start in service mode.  Steampipe prints connection information to the console that you can use in connection strings for your application or 3rd party tools:
-```
+
+```bash
 $ steampipe service start
 
 Steampipe service is running:
@@ -30,10 +31,10 @@ Managing the Steampipe service:
 
   # Get status of the service
   steampipe service status
-  
+
   # Restart the service
   steampipe service restart
-  
+
   # Stop the service
   steampipe service stop
 
@@ -66,10 +67,41 @@ Managing the Steampipe service:
 
   # Get status of the service
   steampipe service status
-  
+
   # Restart the service
   steampipe service restart
-  
+
+  # Stop the service
+  steampipe service stop
+
+```
+
+## Starting database with a private key protected with a passphrase
+
+You can run `steampipe service start` with a private key protected with a passphrase, use the `--database-ssl-password` flag
+
+```bash
+$ steampipe service start --database-ssl-password my-passphrase
+
+Steampipe service is running:
+
+Database:
+
+  Host(s):            localhost, 127.0.0.1, 192.168.10.174
+  Port:               9193
+  Database:           steampipe
+  User:               steampipe
+  Password:           4cbe-4bc2-9c18
+  Connection string:  postgres://steampipe:4cbe-4bc2-9c18@localhost:9193/steampipe
+
+Managing the Steampipe service:
+
+  # Get status of the service
+  steampipe service status
+
+  # Restart the service
+  steampipe service restart
+
   # Stop the service
   steampipe service stop
 

--- a/docs/reference/env-vars/overview.md
+++ b/docs/reference/env-vars/overview.md
@@ -24,6 +24,7 @@ Note that plugins may also support environment variables, but these are plugin-s
 | [STEAMPIPE_CLOUD_HOST](reference/env-vars/steampipe_cloud_host)  | `pipes.turbot.com` | Set the Turbot Pipes host, for connecting to Turbot Pipes workspace.
 | [STEAMPIPE_CLOUD_TOKEN](reference/env-vars/steampipe_cloud_token)  |  | Set the Turbot Pipes authentication token for connecting to Turbot Pipes workspace.
 | [STEAMPIPE_DATABASE_PASSWORD](reference/env-vars/steampipe_database_password)| randomly generated | Set the steampipe database password for this session.  This variable must be set when the steampipe service starts.
+| [STEAMPIPE_DATABASE_SSL_PASSWORD](reference/env-vars/steampipe_database_ssl_password)|  | Set the server key passphrase for this session.  This variable must be set when the server private key is protected with a passphrase.
 | [STEAMPIPE_DATABASE_START_TIMEOUT](reference/env-vars/steampipe_database_start_timeout)| `30` | Set the maximum time (in seconds) to wait for the Postgres process to start accepting queries after it has been started.
 | [STEAMPIPE_DIAGNOSTIC_LEVEL](reference/env-vars/steampipe_diagnostic_level)| `NONE` | Sets the diagnostic level.  Supported levels are `ALL`, `NONE`.
 | [STEAMPIPE_INSTALL_DIR](reference/env-vars/steampipe_install_dir)| `~/.steampipe` | The directory in which the Steampipe database, plugins, and supporting files can be found.

--- a/docs/reference/env-vars/steampipe_database_ssl_password.md
+++ b/docs/reference/env-vars/steampipe_database_ssl_password.md
@@ -9,7 +9,7 @@ sidebar_label: STEAMPIPE_DATABASE_SSL_PASSWORD
 Sets the `server.key` passphrase.  By default, this value is empty because of steampipe that generates a certificate without passphrase.  To use your own certificate, set the `STEAMPIPE_DATABASE_SSL_PASSWORD` variable and start the steampipe service.
 
 Note the following:
-- If the `--database-ssl-password` is passed to `steampipe service start`, steampipe will behave as if the key were protected by a passphrase.
+- If `STEAMPIPE_DATABASE_SSL_PASSWORD` is passed to `steampipe service start`, steampipe will behave as if the key were protected by a passphrase.
 - The `server.key` content **must** contains [Proc-Type](https://datatracker.ietf.org/doc/html/rfc1421#section-4.6.1.1) and [DEK-Info](https://datatracker.ietf.org/doc/html/rfc1421#section-4.6.1.3) headers.
 
 ## Usage 

--- a/docs/reference/env-vars/steampipe_database_ssl_password.md
+++ b/docs/reference/env-vars/steampipe_database_ssl_password.md
@@ -1,0 +1,22 @@
+---
+title: STEAMPIPE_DATABASE_SSL_PASSWORD
+sidebar_label: STEAMPIPE_DATABASE_SSL_PASSWORD
+---
+
+
+# STEAMPIPE_DATABASE_SSL_PASSWORD
+
+Sets the `server.key` passphrase.  By default, this value is empty because of steampipe that generates a certificate without passphrase.  To use your own certificate, set the `STEAMPIPE_DATABASE_SSL_PASSWORD` variable and start the steampipe service.
+
+Note the following:
+- If the `--database-ssl-password` is passed to `steampipe service start`, steampipe will behave as if the key were protected by a passphrase.
+- The `server.key` content **must** contains [Proc-Type](https://datatracker.ietf.org/doc/html/rfc1421#section-4.6.1.1) and [DEK-Info](https://datatracker.ietf.org/doc/html/rfc1421#section-4.6.1.3) headers.
+
+## Usage 
+Start the steampipe service with a custom password:
+
+```bash
+export STEAMPIPE_DATABASE_SSL_PASSWORD=MyPassPhrase
+steampipe service start
+```
+


### PR DESCRIPTION
If this [PR](https://github.com/turbot/steampipe/pull/4152) is merged, the doc should add info about the new env var to handle private key with passphrase