### PR TITLE
✏️ update installation script url

### DIFF
--- a/docs/integrations/cloud9.md
+++ b/docs/integrations/cloud9.md
@@ -11,7 +11,7 @@ sidebar_label: AWS Cloud9
 To install Steampipe, paste this command in your AWS Cloud9 terminal.
 
 ```
-sudo /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/turbot/steampipe/main/install.sh)"
+sudo /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/turbot/steampipe/main/scripts/install.sh)"
 ```
 
 <div style={{"marginBottom":"2em","borderWidth":"thin", "borderStyle":"solid", "borderColor":"lightgray", "padding":"20px", "width":"100%"}}>


### PR DESCRIPTION
Documentation on https://steampipe.io/docs/integrations/cloud9 use a wrong URL link for installation link.
This PR fix the link to match correct location.