### PR TITLE
update sdk to v5 in code examples

### DIFF
--- a/docs/develop/writing-plugins.md
+++ b/docs/develop/writing-plugins.md
@@ -60,8 +60,8 @@ package zendesk
 import (
 	"context"
 
-	"github.com/turbot/steampipe-plugin-sdk/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 )
 
 func Plugin(ctx context.Context) *plugin.Plugin {
@@ -851,8 +851,8 @@ import (
 
 	"github.com/nukosuke/go-zendesk/zendesk"
 
-	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 
 func tableZendeskUser() *plugin.Table {

--- a/docs/develop/writing_plugins/the-basics.md
+++ b/docs/develop/writing_plugins/the-basics.md
@@ -50,8 +50,8 @@ package zendesk
 import (
 	"context"
 
-	"github.com/turbot/steampipe-plugin-sdk/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 )
 
 func Plugin(ctx context.Context) *plugin.Plugin {


### PR DESCRIPTION
Update some code examples to use steampipe-plugin-sdk v5.
This will avoid some issues when developing a plugin.