### PR TITLE
docs: fix plugin options table formatting

### DIFF
--- a/docs/reference/config-files/plugin.md
+++ b/docs/reference/config-files/plugin.md
@@ -18,9 +18,10 @@ plugin "aws" {
 ```
 
 
-## Supported options  
-| Argument | Default | Description 
-|-|-|-|-
+## Supported options
+
+| Argument | Default | Description
+|-|-|-
 | `source`        | none   |  A [plugin version string](#plugin-version-strings) the specifies which plugin this configuration applies to.  If not specified, the plugin block label is assumed to be the plugin source. <!--This must refer to an [installed plugin version](/docs/managing/plugins#installing-plugins). -->
 | `memory_max_mb` | `1024` | The soft memory limit for the plugin, in MB. Steampipe sets `GOMEMLIMIT` for the plugin process to the specified value.  The Go runtime does not guarantee that the memory usage will not exceed the limit, but rather uses it as a target to optimize garbage collection.
 | `limiter`       | none   | Optional [limiter](#limiter) blocks used to set concurrency and/or rate limits


### PR DESCRIPTION
Without this PR, the table is not properly formatted:

https://steampipe.io/docs/reference/config-files/plugin#supported-options: 
![image](https://github.com/user-attachments/assets/1a75c6ef-c185-4035-ac3d-6af7afb7faef)

https://github.com/turbot/steampipe-docs/blob/main/docs/reference/config-files/plugin.md:
![image](https://github.com/user-attachments/assets/552bea41-ef25-4482-a11a-58fac4044461)

With this PR:

https://github.com/pdecat/steampipe-docs/blob/74c24db2a43422e3917537ec9c6655736cbc03e2/docs/reference/config-files/plugin.md:
![image](https://github.com/user-attachments/assets/85fd8fa4-ec68-4fd7-9b1a-47fc4c0dd609)
